### PR TITLE
Add Scala 2.13.0-RC1 to compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
-val Scala_2_11 = "2.11.11"
+val Scala_2_11 = "2.11.12"
 val Scala_2_12 = "2.12.8"
+val Scala_2_13 = "2.13.0-RC1"
 
 inThisBuild(
   List(
@@ -17,7 +18,6 @@ inThisBuild(
   ))
 
 val compilerPlugins = List(
-  compilerPlugin("org.scalamacros" % "paradise" % "2.1.1").cross(CrossVersion.full),
   compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.10")
 )
 
@@ -25,14 +25,14 @@ val commonSettings = Seq(
   scalaVersion := "2.11.11",
   Options.addAll,
   fork in Test := true,
-  crossScalaVersions := Seq(Scala_2_11, Scala_2_12),
+  crossScalaVersions := Seq(Scala_2_11, Scala_2_12, Scala_2_13),
   name := "slick-effect",
   libraryDependencies ++= Seq(
-    "com.typesafe.slick" %% "slick" % "3.3.0",
-    "org.typelevel" %% "cats-effect" % "1.3.0",
-    "org.typelevel" %% "cats-testkit" % "1.6.0" % Test,
-    "org.typelevel" %% "cats-effect-laws" % "1.3.0" % Test,
-    "org.scalatest" %% "scalatest" % "3.0.7" % Test,
+    "com.typesafe.slick" %% "slick" % "3.4.0-SNAPSHOT",
+    "org.typelevel" %% "cats-effect" % "2.0.0-M1",
+    "org.typelevel" %% "cats-testkit" % "2.0.0-M1" % Test,
+    "org.typelevel" %% "cats-effect-laws" % "2.0.0-M1" % Test,
+    "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test,
     "com.h2database" % "h2" % "1.4.199" % Test
   ) ++ compilerPlugins
 )

--- a/project/Options.scala
+++ b/project/Options.scala
@@ -4,10 +4,8 @@ object Options {
 
   //from https://tpolecat.github.io/2017/04/25/scalac-flags.html
   val addAll = {
-    val scala_2_11Options = Seq(
+    val scala_2_11Options = Set(
       "-deprecation", // Emit warning and location for usages of deprecated APIs.
-      "-encoding",
-      "utf-8", // Specify character encoding used by source files.
       "-explaintypes", // Explain type errors in more detail.
       "-feature", // Emit warning and location for usages of features that should be imported explicitly.
       "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
@@ -44,7 +42,7 @@ object Options {
       "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
     )
 
-    val scala_2_12Options = scala_2_11Options ++ Seq (
+    val scala_2_12Options = scala_2_11Options ++ Set(
       "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
       "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
       "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
@@ -55,6 +53,28 @@ object Options {
       "-Ywarn-unused:privates", // Warn if a private member is unused.
     )
 
-    scalacOptions ++= (if(scalaVersion.value.startsWith("2.11")) scala_2_11Options else scala_2_12Options)
+    val scala_2_13Options = scala_2_12Options -- Set(
+      "-Xlint:by-name-right-associative",
+      "-Xlint:unsound-match",
+      "-Yno-adapted-args",
+      "-Ywarn-nullary-unit",
+      "-Ywarn-inaccessible",
+      "-Ypartial-unification",
+      "-Ywarn-infer-any",
+      "-Ywarn-nullary-override",
+      "-Ywarn-unused:params",
+      "-Xlint:type-parameter-shadow",
+      "-Xfuture",
+      "-deprecation"
+    ) ++ List("-Xlint:deprecation")
+
+    scalacOptions ++= (scalaVersion.value match {
+      case v if v.startsWith("2.11") => scala_2_11Options
+      case v if v.startsWith("2.12") => scala_2_12Options
+      case v if v.startsWith("2.13") => scala_2_13Options
+    }).toList ++ List(
+      "-encoding",
+      "utf-8", // Specify character encoding used by source files.
+    )
   }
 }

--- a/src/main/scala/slickeffect/Transactor.scala
+++ b/src/main/scala/slickeffect/Transactor.scala
@@ -5,7 +5,6 @@ import cats.effect.implicits._
 import cats.~>
 import slick.basic.{BasicBackend, BasicProfile, DatabaseConfig}
 import slick.dbio.DBIO
-import cats.implicits._
 
 trait Transactor[F[_]] {
   def transact[A](dbio: DBIO[A]): F[A] = transactK(dbio)


### PR DESCRIPTION
Blocked on:
- [ ] Slick releasing for 2.13.0-RC1 (had to publish a snapshot locally)